### PR TITLE
QLD Open Data Sprint 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Make sure to use indentation if the value spans multiple lines otherwise it won'
 
 If you are using a cloud-based storage backend for uploads check [Private datasets](#private-datasets) for other configuration settings that might be relevant.
 
+### Display badges
+
+To prevent the extension from adding the validation badges next to the resources use the following option:
+
+    ckanext.validation.show_badges_in_listings = False
+
 
 ## How it works
 


### PR DESCRIPTION
This PR is to address the issue of the edit resource page scrolling down to the bottom on page load.
This is already happening currently in production but has become more noticeable because we have added more resource metadata fields to the form for [DQL3-2](https://salsadigital.atlassian.net/browse/DQL3-2) & [DQL3-3](https://salsadigital.atlassian.net/browse/DQL3-3) which now requires scrolling back to the top to change the URL field.
Emil found this in QA and here is his comment https://salsadigital.atlassian.net/browse/DQL3-2?focusedCommentId=171958 