### PR TITLE
[QOL-7740] ensure 'six' is new enough for transitive dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,10 @@
 behave==1.2.6
 behaving==1.5.6
 factory-boy==2.1.1
-flake8==3.7.9
+flake8==3.8.3
 mock
 nose==1.3.7
-splinter>=0.13.0
--e git+https://github.com/ckan/ckanapi@ckanapi-4.3#egg=ckanapi
 pyfakefs==2.7
+selenium==3.141.0
+splinter>=0.13.0
+git+https://github.com/ckan/ckanapi@ckanapi-4.3#egg=ckanapi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,5 +6,5 @@ mock
 nose==1.3.7
 pyfakefs==2.7
 selenium==3.141.0
-splinter>=0.13.0
+splinter>=0.13.0,<0.17
 git+https://github.com/ckan/ckanapi@ckanapi-4.3#egg=ckanapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ckantoolkit>=0.0.3
 goodtables==1.5.1
-six>=1.0.0
+six>=1.13.0
 pyrsistent<0.17.0
 -e git+https://github.com/ckan/ckanext-scheming.git@release-2.1.0#egg=ckanext-scheming


### PR DESCRIPTION
Latest version of 'pathlib2' depends on `six.moves.collections_abc`

See https://github.com/jazzband/pathlib2/issues/81