### PR TITLE
QOL-7740 prepare for CKAN 2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ckan-version: [2.8.8]
+        ckan-version: [2.8.8, 2.9.4]
 
     name: Continuous Integration build on CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest

--- a/ckanext/validation/logic.py
+++ b/ckanext/validation/logic.py
@@ -607,7 +607,7 @@ def resource_update(original_action, context, data_dict):
             and upload.filename is not None
             and isinstance(upload, uploader.ResourceUpload))
         _run_sync_validation(
-            id, local_upload=is_local_upload, new_resource=True)
+            id, local_upload=is_local_upload, new_resource=False)
 
     # Custom code ends
 

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -138,7 +138,7 @@ Please run the following to create the database tables:
         schema_url = data_dict.pop(u'schema_url', None)
         schema_json = data_dict.pop(u'schema_json', None)
         log.debug("Populating schema; schema_upload is [%s], schema_url is [%s], schema_json is [%s]",
-                 schema_upload, schema_url, schema_json)
+                  schema_upload, schema_url, schema_json)
 
         if isinstance(schema_upload, ALLOWED_UPLOAD_TYPES):
             log.debug("Populating schema from schema_upload")

--- a/ckanext/validation/plugin.py
+++ b/ckanext/validation/plugin.py
@@ -1,6 +1,5 @@
 # encoding: utf-8
 
-import cgi
 import json
 import logging
 import os
@@ -9,6 +8,7 @@ import six
 import ckan.plugins as p
 import ckantoolkit as t
 from ckan.lib.plugins import DefaultTranslation
+from ckan.lib.uploader import ALLOWED_UPLOAD_TYPES, _get_underlying_file
 
 
 from ckanext.validation import settings
@@ -137,15 +137,20 @@ Please run the following to create the database tables:
         schema_upload = data_dict.pop(u'schema_upload', None)
         schema_url = data_dict.pop(u'schema_url', None)
         schema_json = data_dict.pop(u'schema_json', None)
+        log.debug("Populating schema; schema_upload is [%s], schema_url is [%s], schema_json is [%s]",
+                 schema_upload, schema_url, schema_json)
 
-        if isinstance(schema_upload, cgi.FieldStorage):
-            data_dict[u'schema'] = schema_upload.file.read()
+        if isinstance(schema_upload, ALLOWED_UPLOAD_TYPES):
+            log.debug("Populating schema from schema_upload")
+            data_dict[u'schema'] = _get_underlying_file(schema_upload).read()
         elif schema_url:
             if (not isinstance(schema_url, six.string_types)
                     or not schema_url.lower()[:4] == u'http'):
                 raise t.ValidationError({u'schema_url': 'Must be a valid URL'})
+            log.debug("Populating schema from schema_url")
             data_dict[u'schema'] = schema_url
         elif schema_json:
+            log.debug("Populating schema from schema_json")
             data_dict[u'schema'] = schema_json
 
         return data_dict

--- a/ckanext/validation/tests/helpers.py
+++ b/ckanext/validation/tests/helpers.py
@@ -7,6 +7,7 @@ from pyfakefs import fake_filesystem
 
 import ckan.lib.uploader
 from ckan.tests.helpers import change_config
+from ckantoolkit import check_ckan_version
 
 
 INVALID_CSV = '''a,b,c,d
@@ -140,11 +141,14 @@ def mock_uploads(func):
     return wrapper
 
 
-class MockFieldStorage(cgi.FieldStorage):
+if check_ckan_version('2.9'):
+    from werkzeug.datastructures import FileStorage as MockFieldStorage
+else:
+    class MockFieldStorage(cgi.FieldStorage):
 
-    def __init__(self, fp, filename):
+        def __init__(self, fp, filename):
 
-        self.file = fp
-        self.filename = filename
-        self.name = 'upload'
-        self.list = None
+            self.file = fp
+            self.filename = filename
+            self.name = 'upload'
+            self.list = None

--- a/ckanext/validation/tests/test_form.py
+++ b/ckanext/validation/tests/test_form.py
@@ -26,18 +26,6 @@ else:
     EDIT_RESOURCE_URL = '/dataset/{}/resource_edit/{}'
 
 
-def _log_in_as_sysadmin(app):
-    admin_pass = "RandomPassword123"
-    sysadmin = factories.Sysadmin(password=admin_pass)
-
-    # get the form
-    _post(app, "/login_generic?came_from=/user/logged_in", {
-        "save": "",
-        "login": sysadmin["name"],
-        "password": admin_pass,
-    })
-
-
 def _post(app, url, data, upload=None):
     args = []
     if check_ckan_version('2.9'):
@@ -51,7 +39,14 @@ def _post(app, url, data, upload=None):
             'extra_environ': {'REMOTE_USER': user['name'].encode('ascii')}
         }
     else:
-        _log_in_as_sysadmin(app)
+        admin_pass = "RandomPassword123"
+        sysadmin = factories.Sysadmin(password=admin_pass)
+        app.post("/login_generic?came_from=/user/logged_in", params={
+            "save": "",
+            "login": sysadmin["name"],
+            "password": admin_pass,
+        })
+
         args.append(url)
         kwargs = {
             'params': data,

--- a/ckanext/validation/tests/test_jobs.py
+++ b/ckanext/validation/tests/test_jobs.py
@@ -194,7 +194,7 @@ class TestValidationJob(object):
 
         resource = call_action(
             'resource_create',
-            format='csv', upload=mock_upload, package_id=self.test_dataset['id']
+            format='csv', url_type='upload', upload=mock_upload, package_id=self.test_dataset['id']
         )
 
         invalid_stream = io.BufferedReader(io.BytesIO(invalid_csv))

--- a/ckanext/validation/tests/test_logic.py
+++ b/ckanext/validation/tests/test_logic.py
@@ -458,6 +458,7 @@ class TestResourceValidationOnCreate(object):
                     'resource_create',
                     package_id=self.test_dataset['id'],
                     format='CSV',
+                    url_type='upload',
                     upload=mock_upload
                 )
 
@@ -486,6 +487,7 @@ class TestResourceValidationOnCreate(object):
                     'resource_create',
                     package_id=self.test_dataset['id'],
                     format='CSV',
+                    url_type='upload',
                     upload=mock_upload
                 )
 
@@ -511,6 +513,7 @@ class TestResourceValidationOnCreate(object):
                 'resource_create',
                 package_id=self.test_dataset['id'],
                 format='CSV',
+                url_type='upload',
                 upload=mock_upload
             )
 
@@ -566,6 +569,7 @@ class TestResourceValidationOnUpdate(object):
                     id=dataset['resources'][0]['id'],
                     package_id=dataset['id'],
                     format='CSV',
+                    url_type='upload',
                     upload=mock_upload
                 )
 
@@ -600,6 +604,7 @@ class TestResourceValidationOnUpdate(object):
                     id=dataset['resources'][0]['id'],
                     package_id=dataset['id'],
                     format='CSV',
+                    url_type='upload',
                     upload=mock_upload
                 )
 
@@ -632,6 +637,7 @@ class TestResourceValidationOnUpdate(object):
                 id=dataset['resources'][0]['id'],
                 package_id=dataset['id'],
                 format='CSV',
+                url_type='upload',
                 upload=mock_upload
             )
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+beautifulsoup4==4.9.1
 behave==1.2.6
 behaving==1.5.6
 ckanapi==4.3


### PR DESCRIPTION
- Add support for uploads using Werkzeug FileStorage instead of CGI FieldStorage.
- Alter tests to not rely on Webtest API.
- Fix synchronous update validation to not delete resources that fail.