### PR TITLE
QOLDEV-323 prepare for CKAN 2.10

### DIFF
--- a/.docker/scripts/create-test-data.sh
+++ b/.docker/scripts/create-test-data.sh
@@ -73,82 +73,10 @@ curl -LsH "Authorization: ${API_KEY}" \
 # END.
 #
 
-# Creating test data hierarchy which creates organisations assigned to datasets
-ckan_cli create-test-data hierarchy
-
 # Creating basic test data which has datasets with resources
-ckan_cli create-test-data basic
-
-add_user_if_needed organisation_admin "Organisation Admin" organisation_admin@localhost
-add_user_if_needed editor "Publisher" publisher@localhost
-add_user_if_needed foodie "Foodie" foodie@localhost
-add_user_if_needed group_admin "Group Admin" group_admin@localhost
-add_user_if_needed walker "Walker" walker@localhost
-
-echo "Assigning test Datasets to Organisation..."
-
-echo "Updating annakarenina to use ${TEST_ORG_TITLE} organisation:"
-package_owner_org_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=annakarenina&organization_id=${TEST_ORG_NAME}" \
-    ${CKAN_ACTION_URL}/package_owner_org_update
-)
-echo ${package_owner_org_update}
-
-echo "Updating warandpeace to use ${TEST_ORG_TITLE} organisation:"
-package_owner_org_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=warandpeace&organization_id=${TEST_ORG_NAME}" \
-    ${CKAN_ACTION_URL}/package_owner_org_update
-)
-echo ${package_owner_org_update}
-
-echo "Updating organisation_admin to have admin privileges in the department-of-health Organisation:"
-organisation_admin_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=department-of-health&username=organisation_admin&role=admin" \
-    ${CKAN_ACTION_URL}/organization_member_create
-)
-echo ${organisation_admin_update}
-
-echo "Updating publisher to have editor privileges in the department-of-health Organisation:"
-publisher_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=department-of-health&username=editor&role=editor" \
-    ${CKAN_ACTION_URL}/organization_member_create
-)
-echo ${publisher_update}
-
-echo "Updating foodie to have admin privileges in the food-standards-agency Organisation:"
-foodie_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=food-standards-agency&username=foodie&role=admin" \
-    ${CKAN_ACTION_URL}/organization_member_create
-)
-echo ${foodie_update}
-
-echo "Creating non-organisation group:"
-group_create=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "name=silly-walks" \
-    ${CKAN_ACTION_URL}/group_create
-)
-echo ${group_create}
-
-echo "Updating group_admin to have admin privileges in the silly-walks group:"
-group_admin_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=silly-walks&username=group_admin&role=admin" \
-    ${CKAN_ACTION_URL}/group_member_create
-)
-echo ${group_admin_update}
-
-echo "Updating walker to have editor privileges in the silly-walks group:"
-walker_update=$( \
-    curl -LsH "Authorization: ${API_KEY}" \
-    --data "id=silly-walks&username=walker&role=editor" \
-    ${CKAN_ACTION_URL}/group_member_create
-)
-echo ${walker_update}
+curl -LsH "Authorization: ${API_KEY}" \
+    --data '{"name": "warandpeace", "owner_org": "'"${TEST_ORG_ID}"'",
+"author_email": "admin@localhost", "license_id": "other-open", "notes": "test"}' \
+    ${CKAN_ACTION_URL}/package_create
 
 . ${APP_DIR}/scripts/deactivate

--- a/.docker/test.ini
+++ b/.docker/test.ini
@@ -56,6 +56,8 @@ ckan.datastore.default_fts_index_method = gist
 ## Site Settings.
 ckan.site_url = http://ckan:5000/
 
+ckan.auth.create_unowned_dataset=true
+
 ## Search Settings
 
 ckan.site_id = default

--- a/ckanext/validation/tests/fixtures.py
+++ b/ckanext/validation/tests/fixtures.py
@@ -20,7 +20,7 @@ fake = Faker()
 @pytest.fixture
 def validation_setup(monkeypatch, ckan_config, tmpdir):
     monkeypatch.setitem(ckan_config, u'ckan.storage_path', str(tmpdir))
-    monkeypatch.setattr(uploader, u'_storage_path', str(tmpdir))
+    monkeypatch.setattr(uploader, u'get_storage_path', lambda: str(tmpdir))
 
     if not tables_exist():
         create_tables()

--- a/ckanext/validation/tests/test_plugin.py
+++ b/ckanext/validation/tests/test_plugin.py
@@ -95,7 +95,7 @@ class TestResourceControllerHooksUpdate(object):
         """Validation must be triggered during update on changing format"""
         resource = resource_factory(format="PDF")
 
-        assert mock_enqueue.not_called()
+        mock_enqueue.assert_not_called()
 
         resource['format'] = 'CSV'
 
@@ -109,7 +109,7 @@ class TestResourceControllerHooksUpdate(object):
         validation_options"""
         resource = resource_factory(format="PDF")
 
-        assert mock_enqueue.not_called()
+        mock_enqueue.assert_not_called()
 
         resource['validation_options'] = {'headers': 1, 'skip_rows': ['#']}
         resource['format'] = 'CSV'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,4 +9,4 @@ pytest-ckan
 pytest-cov
 selenium==3.141.0
 splinter>=0.13.0,<0.17
-faker==3.0.1
+faker==18.3.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,6 @@ mock
 pyfakefs==2.7
 pytest-ckan
 pytest-cov
-selenium==3.141.0
-splinter>=0.13.0,<0.17
+selenium==4.8.2
+splinter>=0.13.0
 faker==18.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ckantoolkit>=0.0.3
 goodtables==1.5.1
 six>=1.13.0
--e git+https://github.com/ckan/ckanext-scheming.git@release-2.1.0#egg=ckanext-scheming
+-e git+https://github.com/ckan/ckanext-scheming.git@release-3.0.0#egg=ckanext-scheming

--- a/test/features/environment.py
+++ b/test/features/environment.py
@@ -36,21 +36,6 @@ PERSONAS = {
         'email': u'group_admin@localhost',
         'password': u'Password123!'
     },
-    'Publisher': {
-        'name': u'editor',
-        'email': u'publisher@localhost',
-        'password': u'Password123!'
-    },
-    'Walker': {
-        'name': u'walker',
-        'email': u'walker@localhost',
-        'password': u'Password123!'
-    },
-    'Foodie': {
-        'name': u'foodie',
-        'email': u'foodie@localhost',
-        'password': u'Password123!'
-    },
     'TestOrgAdmin': {
         'name': u'test_org_admin',
         'email': u'test_org_admin@localhost',


### PR DESCRIPTION
- Generate test data via API (which is more stable) instead of CLI
- Adjust configuration to handle CKAN 2.10 defaults
- Update test dependencies
- Replace deprecated code that won't work in 2.10